### PR TITLE
Updated map_handler.py for python 3.11 interpreter

### DIFF
--- a/src/handlers/map_handler.py
+++ b/src/handlers/map_handler.py
@@ -82,6 +82,7 @@ class MapHandler:
         finder = DijkstraFinder()
         path, runs = finder.find_path(start, end, grid)
         next_cell = path[-len(path)+1]
+        next_cell = list(next_cell)
         best_move = (next_cell[1] - seeker_pos[0], next_cell[0] - seeker_pos[1])
         best_action = self._move_to_action(best_move)
         return best_action


### PR DESCRIPTION
#1 
Resolved a small bug giving error as :
" line 86, in _compute_best_seeker_action
best_move = (next_cell[1] - seeker_pos[0], next_cell[0] - seeker_pos[1])
~~~~~~~~~^^^
TypeError: 'GridNode' object is not subscriptable
ImportError: sys.meta_path is None, Python is likely shutting down "

Solution:
typecasted the next_cell with list()